### PR TITLE
Add Git info to pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,9 @@ pluralizelisttitles = false
 
 disablePathToLower = true
 
+# https://gohugo.io/variables/git/
+enableGitInfo = true
+
 # https://gohugo.io/getting-started/configuration/#blackfriday-options
 [blackfriday]
 fractions = false
@@ -18,6 +21,7 @@ fractions = false
 [params]
     webchatBaseURL = "https://webchat.snoonet.org/"
     redditBaseURL  = "https://reddit.com"
+    repositoryURL  = "https://github.com/snoonetIRC/static-web/"
 
     [params.communityTypes]
         [[params.communityTypes.beauty_and_relationships]]

--- a/themes/Snoonet/layouts/partials/footer.html
+++ b/themes/Snoonet/layouts/partials/footer.html
@@ -4,6 +4,9 @@
 
                 <footer id="footer">
                     <ul>
+                        {{ if eq .Kind "page" }}
+                            {{ partial "git.html" . }}
+                        {{ end }}
                         <li>&copy; {{ now.Format "2006"}} Snoonet</li>
                     </ul>
                 </footer>

--- a/themes/Snoonet/layouts/partials/git.html
+++ b/themes/Snoonet/layouts/partials/git.html
@@ -1,0 +1,11 @@
+<em>
+    <a
+        href="{{ .Site.Params.repositoryURL }}commit/{{ .GitInfo.Hash }}"
+    >
+        {{ .GitInfo.AbbreviatedHash }}
+    </a>
+    &middot;
+    {{ .GitInfo.AuthorName }}
+    &middot;
+    {{ dateFormat "Mon, Jan 2, 2006 15:04:05" .GitInfo.AuthorDate }}
+</em>

--- a/themes/Snoonet/layouts/partials/git.html
+++ b/themes/Snoonet/layouts/partials/git.html
@@ -2,6 +2,7 @@
 
 {{ with .GitInfo }}
     <em>
+        Last modification:
         <a
             href="{{ $repoURL }}commit/{{ .Hash }}"
         >

--- a/themes/Snoonet/layouts/partials/git.html
+++ b/themes/Snoonet/layouts/partials/git.html
@@ -1,11 +1,15 @@
-<em>
-    <a
-        href="{{ .Site.Params.repositoryURL }}commit/{{ .GitInfo.Hash }}"
-    >
-        {{ .GitInfo.AbbreviatedHash }}
-    </a>
-    &middot;
-    {{ .GitInfo.AuthorName }}
-    &middot;
-    {{ dateFormat "Mon, Jan 2, 2006 15:04:05" .GitInfo.AuthorDate }}
-</em>
+{{ $repoURL := .Site.Params.repositoryURL }}
+
+{{ with .GitInfo }}
+    <em>
+        <a
+            href="{{ $repoURL }}commit/{{ .Hash }}"
+        >
+            {{ .AbbreviatedHash }}
+        </a>
+        &middot;
+        {{ .AuthorName }}
+        &middot;
+        {{ dateFormat "Mon, Jan 2, 2006 15:04:05" .AuthorDate }}
+    </em>
+{{ end }}


### PR DESCRIPTION
![2019-06-06-092143_1089x246_scrot](https://user-images.githubusercontent.com/2040110/59017987-c2da1c00-883c-11e9-9163-64e2d75ac499.png)

* Displays on posts & pages.
* Currently doesn't display on "multipage" files (i.e. help, rules) - I think these probably need rethinking (I'll sort that in another branch).
* Doesn't display on the main "Updates" index (because those are summary pages).