### PR TITLE
remove to link to A-D staff page as he's not staff

### DIFF
--- a/content/community/depression.md
+++ b/content/community/depression.md
@@ -31,7 +31,7 @@ Please understand that although we are here to provide peer support, our channel
 - Caeli
 
 ### Channel Staff: 
-- [A_D](/staff/a_d)
+- A_D
 - AHare
 - GhostyOne
 - jglauche


### PR DESCRIPTION
also would suggest removing imalive from the links because they are horrid.