### PR TITLE
Add and use email shortcode (fixes #92)

### DIFF
--- a/content/banexempt.md
+++ b/content/banexempt.md
@@ -23,7 +23,7 @@ Some users are malicious and try to ruin it for many others, however we are here
 
 ## What to do
 
-For us to add an exemption so that you are not banned. Please e-mail support@snoonet.org with your IP address (www.whatismyip.com and copy your IP) the identd that you connect with (If you don't know what it is, state so in the e-mail) and your IRC nickname so we may add an exemption for you specifically. We will e-mail you back within a few minutes and you will be able to connect to our services.
+For us to add an exemption so that you are not banned. Please e-mail {{< email "support" >}} with your IP address (www.whatismyip.com and copy your IP) the identd that you connect with (If you don't know what it is, state so in the e-mail) and your IRC nickname so we may add an exemption for you specifically. We will e-mail you back within a few minutes and you will be able to connect to our services.
 
 Sorry for the inconvenience
 

--- a/content/gsa.md
+++ b/content/gsa.md
@@ -9,7 +9,7 @@ type: page
 
 ## Seeking Game Admins
 
-We are seeking a few active game server administrators for a 32-man TF2 and 16-man Garry's Mod server. As of now, these are the two servers that we will host. If you have other suggestions for games and feel that they'll be popular and widely supported, please e-mail support@snoonet.org with the subject line "Game Server Inquiry." Please include your suggestion and why you feel the game server should be hosted.
+We are seeking a few active game server administrators for a 32-man TF2 and 16-man Garry's Mod server. As of now, these are the two servers that we will host. If you have other suggestions for games and feel that they'll be popular and widely supported, please e-mail {{< email "support" >}} with the subject line "Game Server Inquiry." Please include your suggestion and why you feel the game server should be hosted.
 
 Volunteers will be given full admin privileges to the game server, the ability to upload mods, maps, files, and tools for the game server, and in some cases (for trusted users), SSH access.
 

--- a/content/le-guidelines.md
+++ b/content/le-guidelines.md
@@ -65,7 +65,7 @@ Consistent with 18 U.S.C. § 2703(f), Snoonet will preserve records for up to 90
 4.	Identify the time period for which records are to be preserved (maximum 90 days);
 5.	Confirm that valid legal process is forthcoming;
 6.	Have a valid return official email address; and
-7.	Be sent on law enforcement letterhead to lawenforcement [at] snoonet.org with the subject line reading "Preservation Request – User: [insert relevant username here]".
+7.	Be sent on law enforcement letterhead to {{< email "lawenforcement" >}} with the subject line reading "Preservation Request – User: [insert relevant username here]".
 
 Unless Snoonet receives an additional preservation request, Snoonet will, after 90 days, release the preservation and the preserved records will be subject to Snoonet's normal retention or destruction schedules.
 

--- a/content/le-request.md
+++ b/content/le-request.md
@@ -27,7 +27,7 @@ To submit a preservation request, do the following:
 
 •  For Reddit Username field, fill in your Title and full name (e.g. Officer Joe Smith)
 
-2) Send an email to lawenforcement [at] snoonet.org
+2) Send an email to {{< email "lawenforcement" >}}
 ---
 # <a name="user-information">Requests for Snoonet User Account Information</a>
 
@@ -39,7 +39,7 @@ To submit a Snoonet user account information request, do the following:
 
 • For Reddit Username field, fill in your Title and full name (e.g. Officer Joe Smith)
 
-2) Send an email to lawenforcement [at] snoonet.org
+2) Send an email to {{< email "lawenforcement" >}}
 
 ---
 # <a name="emergency-request">Emergency Disclosure Requests</a>
@@ -52,6 +52,6 @@ To submit an emergency disclosure request, do the following:
 
 • For Reddit Username field, fill in your Title and full name (e.g. Officer Joe Smith)
 
-2) Send an email to LEemergency [at] snoonet.org
+2) Send an email to {{< email "LEemergency" >}}
 
 The request will automatically be assigned an ticket number and an additional form will be sent to you.  Fill out the additional form and attach it to the ticket or reply to the automated email with the completed form.

--- a/content/posts/2012/12/12/snoonet-updates.md
+++ b/content/posts/2012/12/12/snoonet-updates.md
@@ -7,7 +7,7 @@ type: post
 
 # Email Support
 
-We have set up an e-mail for those in need of support if they are having connection issues, or need any type of support outside of the chat network. Any suggestions or requests for any thing Snoonet are **highly encouraged** as well. This can be done by contacting us at **support@snoonet.org** - Be sure to include your nickname in the e-mail!
+We have set up an e-mail for those in need of support if they are having connection issues, or need any type of support outside of the chat network. Any suggestions or requests for any thing Snoonet are **highly encouraged** as well. This can be done by contacting us at {{< email "support" >}} - Be sure to include your nickname in the e-mail!
 
 # Keeping in Touch
 

--- a/content/posts/2013/01/04/snoonet-maintenance.md
+++ b/content/posts/2013/01/04/snoonet-maintenance.md
@@ -1,4 +1,4 @@
---- 
+---
 date: 2013-01-04T06:15:00
 draft: false
 title: "Snoonet Maintenance"
@@ -9,20 +9,15 @@ On Monday, Jan. 7 at 2AM EST we will be issuing updates to the Snoonet IRCd serv
 
 There will be some brief splits as we upgrade the operating systems on two of the nodes. We will be adding more nodes for clients to connect to for both IPv4 and IPv6. As our webchat reaches a more capable stage, these updates will be to prepare for the widespread user count anticipated by newcomers from Reddit Enhancement Suite/Reddit links.
 
-
 We will keep services downtime to a minimum, anticipating very little downtime.
-
 
 Snoonet is working on other projects aside from IRC/live chat services, and more news will be shared as the days come.
 
-
-We are also seeking client servers. We have plenty of servers, but we feel as if they will be of use in the very near future. If you can help, please e-mail Shane@snoonet.org and we will continue from there. Please have advanced knowledge and experience moderating large communities!
-
+We are also seeking client servers. We have plenty of servers, but we feel as if they will be of use in the very near future. If you can help, please e-mail {{< email "shane" >}} and we will continue from there. Please have advanced knowledge and experience moderating large communities!
 
 Snoonet is here for ALL communities, reddit and otherwise. If you'd like to help us provide for the communities, shoot us an e-mail!
 
-If you have any concerns/questions, feel free to post at http://snoonet.reddit.com / e-mail us at support@snoonet.org / ask us in #help
-
+If you have any concerns/questions, feel free to post at http://snoonet.reddit.com / e-mail us at {{< email "support" >}} / ask us in #help
 
 Sincerely,
 Snoonet Staff

--- a/content/posts/2013/01/14/gaming-webchat-network-news.md
+++ b/content/posts/2013/01/14/gaming-webchat-network-news.md
@@ -1,4 +1,4 @@
---- 
+---
 date: 2013-01-14T10:00:00
 draft: false
 title: "01/14/2013 - Gaming, Webchat, Network News"
@@ -14,16 +14,16 @@ Some examples will be a VIP-Ask Me Anything robot which will moderate the channe
 
 A channel protection bot for channel operators/moderators to utilize and change the settings of to set a 'bad words' type filter list, where they may set punishments for bad words, phrases, links, etc. The bot will also have options to control punishing flooding/repeat lines/repeat offenders, as well as manage the ban lists. This is for channels that grow in size and need moderation while operators/mods aren't around. For those familiar with our network bot 'sysop' - it will be a user controlled/managed bot controlled by channel mods.
 
-While the above may be boring/uninteresting to some, 
+While the above may be boring/uninteresting to some,
 
 # Games
-Our network co-founder Paradox and network operator, Ricin will be hosting a large-scale Minecraft server for users to play on. More news will be posted about it as they will require help in moderating the server/keeping an eye on things. If you have any suggestions for other games you'd like hosted, feel free to contact us in {{< webchat channel="#SnoonetGaming" title="SnoonetGaming" >}}, {{< subreddit_link "irc" >}} or e-mail support@snoonet.org.
+Our network co-founder Paradox and network operator, Ricin will be hosting a large-scale Minecraft server for users to play on. More news will be posted about it as they will require help in moderating the server/keeping an eye on things. If you have any suggestions for other games you'd like hosted, feel free to contact us in {{< webchat channel="#SnoonetGaming" title="SnoonetGaming" >}}, {{< subreddit_link "irc" >}} or e-mail {{< email "support" >}}.
 
 We have the resources to host multiple game servers, and will be hosting these servers while we code and produce the competitive gaming tournament aspect of Snoonet.org, where teams can compete in games to win cash, or play for free to win smaller prizes. [More can be read in our mission statement!](/mission-statement).
 
 So in the upcoming days, you'll see a few changes to the webchat, as well as us announcing our Minecraft / other server information.
 
-If you have any suggestions/questions, we can be contacted on IRC in {{< webchat channel="#snoonet" title="#snoonet" >}} - support@snoonet.org or {{< subreddit_link irc >}}.
+If you have any suggestions/questions, we can be contacted on IRC in {{< webchat channel="#snoonet" title="#snoonet" >}} - {{< email "support" >}} or {{< subreddit_link irc >}}.
 
 
 Thank you for reading, and making Snoonet possible!

--- a/content/posts/2013/04/18/hiring-support-staff.md
+++ b/content/posts/2013/04/18/hiring-support-staff.md
@@ -1,4 +1,4 @@
---- 
+---
 date: 2013-04-18T05:44:00
 draft: false
 title: "Hiring Support Staff"
@@ -9,7 +9,7 @@ type: post
 
 # We are asking for 10-15 support staff
 
-# If you'd like to help Snoonet on this journey, e-mail Shane@snoonet.org with:
+# If you'd like to help Snoonet on this journey, e-mail {{< email "shane" >}} with:
 
 - IRC Alias
 - Operator/Staff Experience on IRC

--- a/content/posts/2015/10/29/snoonet-is-hiring-community-staff.md
+++ b/content/posts/2015/10/29/snoonet-is-hiring-community-staff.md
@@ -1,26 +1,26 @@
---- 
+---
 date: 2015-10-29T16:16:00
 draft: false
 title: "Snoonet is hiring community staff!"
 type: post
 ---
 
-Snoonet is looking to hire community staff members.  Applicants should be active and engaged in our IRC communities and be interested in volunteering their time to make the network a better place.   
+Snoonet is looking to hire community staff members.  Applicants should be active and engaged in our IRC communities and be interested in volunteering their time to make the network a better place.
 
-## Responsibilities 
+## Responsibilities
 
-Community staff will assist with various projects designed to improve the user experience on Snoonet.  They will be expected to consult with communities, specifically with an eye to understanding community needs and suggesting tools and policies that should be developed to assist with community moderation and growth.   
+Community staff will assist with various projects designed to improve the user experience on Snoonet.  They will be expected to consult with communities, specifically with an eye to understanding community needs and suggesting tools and policies that should be developed to assist with community moderation and growth.
 
-On a day-to-day basis, responsibilities will also include assisting with support requests in #help and in our ticket system, drafting communications about upcoming events or ongoing issues, and generally providing users and channel operators with support and assistance.   
+On a day-to-day basis, responsibilities will also include assisting with support requests in #help and in our ticket system, drafting communications about upcoming events or ongoing issues, and generally providing users and channel operators with support and assistance.
 
-## Qualifications 
+## Qualifications
 
-We are primarily looking for people with ideas, energy, and a willingness to contribute to the community.  Community staff WILL be network operators, and as such, we are looking for people with knowledge of basic IRC commands, including how to set up channels and assist others in that respect.   
+We are primarily looking for people with ideas, energy, and a willingness to contribute to the community.  Community staff WILL be network operators, and as such, we are looking for people with knowledge of basic IRC commands, including how to set up channels and assist others in that respect.
 
-We are NOT looking for operators who are solely interested in providing network support at this point in time.  Applicants should be interested in working with communities and demonstrate the motivation, creativity, and initiative necessary to succeed on a volunteer team. 
+We are NOT looking for operators who are solely interested in providing network support at this point in time.  Applicants should be interested in working with communities and demonstrate the motivation, creativity, and initiative necessary to succeed on a volunteer team.
 
-## Applications and Inquiries 
+## Applications and Inquiries
 
-If you are interested in applying, please visit [Volunteer Application](/volunteer-recruitment) and send an application to [apply@snoonet.org](mailto:apply@snoonet.org).  
+If you are interested in applying, please visit [Volunteer Application](/volunteer-recruitment) and send an application to {{< email "apply" >}}.
 
 If you have any questions about our community team or our work, please feel free to PM Ari or ScarletAngel.

--- a/content/posts/2016/12/15/update.md
+++ b/content/posts/2016/12/15/update.md
@@ -1,4 +1,4 @@
---- 
+---
 date: 2016-12-15T15:00:00
 draft: false
 title: "12/15/16 Update"
@@ -22,9 +22,9 @@ Our current website is old and outdated. We'd like to keep our active admin back
 - Be laid back, and able to work as a team
 - Take initiative. We'll give you freedom to be yourself and go with the flow. That's how we operate.
 
-
 ## Apply
-# E-mail operations@snoonet.org with:
+
+# E-mail {{ email "operations" }} with:
 - IRC Nick
 - Age
 - Location

--- a/content/posts/2016/12/29/moving-forward.md
+++ b/content/posts/2016/12/29/moving-forward.md
@@ -1,4 +1,4 @@
---- 
+---
 date: 2016-12-29T00:00:00
 draft: false
 title: "Moving Forward!"
@@ -15,7 +15,7 @@ We would like to announce the appointment of bloodygonzo as our new Network Dire
 Jeff "Paradox" Sandberg and Shane "rdv" Allen will be moving to founder roles, retiring from day-to-day operations.  They remain as network owners and will provide input and advice to network operations where appropriate, and will continue to play a role in identifying talent and managing staff.
 
 # [bloodygonzo](/bloodygonzo)
-bloodygonzo has made your network community bot gonzobot! You can see it [here](/gonzobot) and utilize it! He helps new-comers with creating python modules, and has the idea of helping every body that needs something in their community! You can contact bloodygonzo at bloodygonzo@snoonet.org for additional information!
+bloodygonzo has made your network community bot gonzobot! You can see it [here](/gonzobot) and utilize it! He helps new-comers with creating python modules, and has the idea of helping every body that needs something in their community! You can contact bloodygonzo at {{< email "bloodygonzo" >}} for additional information!
 
 # What does this mean?
 We expect to continue to strive towards the goals of our Mission Statement.  We'll continue supporting communities as usual, offering network assistance in #help and discussion in #snoonet.  Expect updates from bloodygonzo in the New Year as we move forward together.

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -20,7 +20,7 @@ This Website ('Snoonet.org'), and its parent IRC.com, (collectively, 'We', 'Us',
 
 From All Users of Our IRC Network
 
-* Internet Protocol (IP) address* for the purposes of account management and protection from abuse. (*You may use a virtual private network or 'bouncer' service if you wish to obscure your IP address) 
+* Internet Protocol (IP) address* for the purposes of account management and protection from abuse. (*You may use a virtual private network or 'bouncer' service if you wish to obscure your IP address)
 * Your user ID or 'nickname' for the purposes of account management and protection from abuse.
 
 From Users Who Have Registered an Account on Our IRC Network
@@ -61,8 +61,8 @@ We retain all account information and data indefinitely unless a client requests
 ---
 ## CalOPPA STATEMENT
 {{< back_to_top >}}
- 
-The State of California requires us to post specific language related to our privacy policy. By default, Snoonet does not share your private information with any third parties aside from the disclosures already made in this privacy policy. However, if you wish to inquire into specifics and verify that Snoonet does not share the personal information of our users with third parties for direct marketing purposes, you may contact [operations@snoonet.org](mailto:operations@snoonet.org).
+
+The State of California requires us to post specific language related to our privacy policy. By default, Snoonet does not share your private information with any third parties aside from the disclosures already made in this privacy policy. However, if you wish to inquire into specifics and verify that Snoonet does not share the personal information of our users with third parties for direct marketing purposes, you may contact {{< email "operations" >}}.
 
 ---
 ## MAINTAINING THE SECURITY OF YOUR PERSONAL INFORMATION
@@ -86,7 +86,7 @@ The Children's Online Privacy Protection Act (COPPA) was passed to give parents 
 ## HOW TO ACCESS AND CONTROL YOUR PERSONAL INFORMATION
 {{< back_to_top >}}
 
-You may access or delete your personal information from the IRC network at any time via a command. To view information shared with Snoonet, use the &ldquo;/msg NickServ INFO &lt;nickname&gt;&rdquo; command. To delete your user account, use the "/msg NickServ DROP &lt;nickname&gt;&rdquo; which requires a secondary confirmation. You may also change the email address associated with your account via a channel command. Another means to delete the personal information maintained by Snoonet is to request that your account information be deleted by the Snoonet support team. The Snoonet support team may be reached at [https://support.snoonet.org](https://support.snoonet.org). 
+You may access or delete your personal information from the IRC network at any time via a command. To view information shared with Snoonet, use the &ldquo;/msg NickServ INFO &lt;nickname&gt;&rdquo; command. To delete your user account, use the "/msg NickServ DROP &lt;nickname&gt;&rdquo; which requires a secondary confirmation. You may also change the email address associated with your account via a channel command. Another means to delete the personal information maintained by Snoonet is to request that your account information be deleted by the Snoonet support team. The Snoonet support team may be reached at [https://support.snoonet.org](https://support.snoonet.org).
 
 ---
 ## CHANGES TO THIS PRIVACY POLICY
@@ -96,10 +96,9 @@ BY CONTINUING TO USE THIS WEBSITE AND/OR SERVICES, YOU AGREE THAT YOU CONSENT TO
 
 Snoonet will not share the personal information of users with third parties for direct marketing purposes.
 
-For all civil or law enforcement requests, please see [Law-Enforcement Guidelines](/le-guidelines) and/or contact [operations@Snoonet.org](mailto:operations@snoonet.org). If you have a request that requires mailing or courier, please see [Law-Enforcement Requests](/le-request).
+For all civil or law enforcement requests, please see [Law-Enforcement Guidelines](/le-guidelines) and/or contact {{< email "operations" >}}. If you have a request that requires mailing or courier, please see [Law-Enforcement Requests](/le-request).
 
 While Snoonet agrees to accept service of law enforcement requests based on the above method listed above, Snoonet does NOT waive any legal rights based on this accommodation.
 
 *Last revised* October 28, 2019
-
 

--- a/content/staff/duck.md
+++ b/content/staff/duck.md
@@ -10,7 +10,7 @@ favorite_channels: "#depression, #fuckduck"
 weight: 2
 ---
 
-# Duck (duck@snoonet.org)
+# Duck {{< email "duck" >}}
 
 Hello all, Duck here! Thanks for flying Snoonet!
 

--- a/content/staff/mike.md
+++ b/content/staff/mike.md
@@ -15,4 +15,4 @@ Hi, I'm Mike.
 You can verify my identity on the network with the client certificate
 fingerprint `5f354892970d867aafe9256a1155160d`.
 
-If you need to e-mail me, you can contact me using mike [at] snoonet.org.
+If you need to e-mail me, you can contact me using {{< email "mike" >}}.

--- a/content/staff/zowlyfon.md
+++ b/content/staff/zowlyfon.md
@@ -14,4 +14,4 @@ Hi, my name is Zowlyfon. I am a Free Software enthusiast studying Computer Scien
 
 I am mainly active in #linuxmasterrace and I can also be contacted in #snoonet or via PM.
 
-My email address is Zowlyfon@snoonet.org
+My email address is {{< email "zowlyfon" >}}.

--- a/content/volunteer-recruitment.md
+++ b/content/volunteer-recruitment.md
@@ -19,5 +19,5 @@ Specifically, community volunteers will work with subreddit communities and prov
 We are primarily looking for people with ideas, energy, and a willingness to contribute to the community. Community volunteers will not be network operators, and as such, extensive familiarity with IRC commands, prior experience, and a specific time commitment are not required. We are looking for people with knowledge of basic IRC commands, including how to set up channels and assist others in that respect. If joining Snoonet staff is something that interests you, this would be a great way to get to know us, gain experience working with our communities, and be considered for future staffing needs.
 
 
-If you are interested in applying, please visit the [Volunteer Application](/volunteer-recruitment) and send an application to [apply@snoonet.org](mailto:apply@snoonet.org).</div>
+If you are interested in applying, please visit the [Volunteer Application](/volunteer-recruitment) and send an application to {{< email "apply" >}}.</div>
 

--- a/themes/Snoonet/assets/scss/screen.scss
+++ b/themes/Snoonet/assets/scss/screen.scss
@@ -298,3 +298,6 @@ hr {
 .clearfix {
     clear: both;
 }
+.email-link {
+  color: #2A4B95;
+}

--- a/themes/Snoonet/layouts/shortcodes/email.html
+++ b/themes/Snoonet/layouts/shortcodes/email.html
@@ -1,0 +1,1 @@
+<span class="email-link">{{ .Get 0 }} [at] snoonet.org</span>


### PR DESCRIPTION
I've gone with the `name [at] snoonet.org` format. If anyone has any strong opinions it's easily changed.