### PR TITLE
Rename Philippines community page

### DIFF
--- a/content/community/philippines.md
+++ b/content/community/philippines.md
@@ -1,9 +1,9 @@
 ---
-aliases: [ 'phillipenes' ]
-title: "#phillipenes"
+aliases: [ 'philippines' ]
+title: "#philippines"
 date: 2019-01-03T09:57:37Z
 draft: false
 type: "community"
 kind: "regional"
-subreddit: "phillipenes"
+subreddit: "philippines"
 ---


### PR DESCRIPTION
# Changelog

## Changed

* Renamed Philippines community page to correct spelling mistake.